### PR TITLE
Make applicationGroupAssignment null by default.

### DIFF
--- a/src/Generated/Applications/Application.php
+++ b/src/Generated/Applications/Application.php
@@ -480,7 +480,7 @@ class Application extends \Okta\Resource\AbstractResource
     *
     * @return mixed|null
     */
-    public function createApplicationGroupAssignment($groupId, ApplicationGroupAssignment $applicationGroupAssignment)
+    public function createApplicationGroupAssignment($groupId, ApplicationGroupAssignment $applicationGroupAssignment = null)
     {
         $uri = "/api/v1/apps/{$this->getId()}/groups/{$groupId}";
         $uri = $this->getDataStore()->buildUri(


### PR DESCRIPTION
Adjusting applicationGroupAssignment as optional field for the createApplicationGroupAssignment() function  to match Official Okta API documentation.

Pull Request for issue #133 

The latest version of this SDK currently requires the ApplicationGroupsAssignment:

```Okta\Generated\Applications\ApplicationGroupAssignment```

This would be okay, but the issue is that is causes PSR7 to throw an exception:

```\PSR7\Stream.php:88``` : ```First argument to Stream::create() must be a string, resource or StreamInterface.```

The current Okta API documentation claims that ApplicationGroupsAssignment is not a required field, and even if we wanted to pass it as a parameter, the action would fail due to the error mentioned above.

![okta_api_current_doc](https://user-images.githubusercontent.com/32472306/136634686-c6d55904-9741-40bf-9ff0-a19f3f6022c1.png)

I suggest making the ApplicationGroupAssignment an optional parameter, just as it is in the Okta Java SDK.

It could just be that i'm initializing it incorrectly, but there's no documentation and I've attempted various ways all with no success.

```
$appGroupAssignment = new ApplicationGroupAssignment();
$application->createApplicationGroupAssignment($group_id, $appGroupAssignment);

Result: First argument to Stream::create() must be a string, resource or StreamInterface.
```