### PR TITLE
Get Group by query and return Group class.

### DIFF
--- a/src/Generated/Groups/Group.php
+++ b/src/Generated/Groups/Group.php
@@ -31,6 +31,22 @@ class Group extends \Okta\Resource\AbstractResource
     const OBJECT_CLASS = 'objectClass';
     const LAST_MEMBERSHIP_UPDATED = 'lastMembershipUpdated';
 
+    /**
+     * @param $query
+     * @return \Okta\Groups\Group
+     */
+    public function get($query)
+    {
+        /** @var $group \Okta\Groups\Group */
+        $group = \Okta\Client::getInstance()
+            ->getDataStore()
+            ->getResource(
+                $query,
+                \Okta\Groups\Group::class,
+                "/groups"
+            );
+        return $group->convertFromGenericGroup();
+    }
 
 
     public function save()
@@ -53,7 +69,7 @@ class Group extends \Okta\Resource\AbstractResource
                     $this
                 );
     }
-        
+
     /**
      * Get the id.
      *
@@ -121,7 +137,7 @@ class Group extends \Okta\Resource\AbstractResource
             self::PROFILE,
             $profile
         );
-        
+
         return $this;
     }
 

--- a/src/Groups/Group.php
+++ b/src/Groups/Group.php
@@ -19,5 +19,14 @@ namespace Okta\Groups;
 
 class Group extends \Okta\Generated\Groups\Group
 {
+    public function convertFromGenericGroup()
+    {
+        $groupClass = \Okta\Groups\Group::class;
+        $properties = new \stdClass();
+        foreach ($this->getPropertyNames() as $name) {
+            $properties->$name = $this->getProperty($name);
+        }
 
+        return new $groupClass(null, $properties);
+    }
 }


### PR DESCRIPTION
This pull request enables the PHP SDK the ability to get Groups via a query, and primarily using a group_id, as the latest version provides no real way of grabbing a single group.

Previously, we would have to get a group collection, and loop through it in order to find the exact group with the following syntax:

```
$okta = new \Okta\Okta
$groupCollection = $okta->getGroups();
... Then loop and match a given $group_id.
```

The previous method forces us to write more code, and create loops in order to match a a group with the group_id that we already have, rather than simply getting a single group, this also causes us to use more bandwidth if a certain app has a large number of groups.

The changes proposed allows us to simply grab a group by it's ID using the following:

```
$group = new Group();
$group = $group->get($group_id);
```

This allows us to grab a group via the Okta API standard using the SDK:

https://developer.okta.com/docs/reference/api/groups/#response-example

![Screen Shot 2021-10-12 at 10 58 47 AM](https://user-images.githubusercontent.com/32472306/137006173-639533fb-6c0c-400d-811f-b5d1679ded9c.png)


